### PR TITLE
remove bind from setTimeout

### DIFF
--- a/tabs/map.js
+++ b/tabs/map.js
@@ -36,7 +36,7 @@ var mapTab = React.createClass({
       (error) => alert(error.message),
       {enableHighAccuracy: true, timeout: 20000, maximumAge: 1000}
     );
-    setTimeout(this.getDataFromServer.bind(this), 1000);
+    setTimeout(this.getDataFromServer, 1000);
   },
   getDataFromServer: function() {
     fetch(config.url+'/locations')


### PR DESCRIPTION
React setTimeout does not require binding to pass the 'this' context
